### PR TITLE
Update remaining ai-dev-tasks references

### DIFF
--- a/.github/workflows/attribution-policy.yml
+++ b/.github/workflows/attribution-policy.yml
@@ -52,7 +52,7 @@ jobs:
 
               ### Why This Policy Exists:
               - AI cannot hold copyright (only humans can be legal authors)
-              - Protects original human contributors' rights (snarktank/ai-dev-tasks)
+              - Protects original human contributors' rights (snarktank/ai-ethics)
               - Complies with open source attribution requirements
 
               **Reference:** [AI_ATTRIBUTION_POLICY.md](/AI_ATTRIBUTION_POLICY.md)

--- a/AI_ATTRIBUTION_POLICY.md
+++ b/AI_ATTRIBUTION_POLICY.md
@@ -2,7 +2,7 @@
 
 **Version:** 1.0
 **Effective Date:** October 27, 2025
-**Repository:** FutureTranz-Inc/ai-dev-tasks
+**Repository:** FutureTranz-Inc/ai-ethics
 
 **Credits:** [FutureTranz-Inc](https://github.com/FutureTranz-Inc) | [victorjquinones](https://github.com/victorjquinones)
 
@@ -28,7 +28,7 @@ This repository PROHIBITS the inclusion of AI attribution in:
 
 1. **Copyright and Authorship**: Copyright authorship and legal accountability attach to natural persons. Attribution in this repository must identify human contributors.
 2. **Attribution Integrity**: Labeling an AI tool as a co-author creates inaccurate authorship metadata and weakens the integrity of project history.
-3. **Open Source Compliance**: Original human contributors (snarktank/ai-dev-tasks and others) must remain accurately credited.
+3. **Open Source Compliance**: Original human contributors (snarktank/ai-ethics and others) must remain accurately credited.
 
 ### Ethical Obligations
 
@@ -38,12 +38,7 @@ This repository PROHIBITS the inclusion of AI attribution in:
 
 ### Original Authors to Honor
 
-This project is built on [snarktank/ai-dev-tasks](https://github.com/snarktank/ai-dev-tasks) created by:
-
-- Ryan Carson (snarktank)
-- 14+ human contributors
-
-Enhanced by:
+This project is built by:
 
 - FutureTranz (Victor J. Quiñones)
 
@@ -84,7 +79,7 @@ The following MUST always be preserved:
 Co-Authored-By: [Human Name] <human@email.com>
 Signed-off-by: [Human Name] <human@email.com>
 
-Based on: snarktank/ai-dev-tasks
+Based on: snarktank/ai-ethics
 Original Author: Ryan Carson
 Prepared by: Victor J. Quiñones (FutureTranz)
 ```
@@ -124,19 +119,19 @@ All pull requests are reviewed for:
 
 ## Implementation
 
-### For ai-dev-tasks Repository
+### For ai-ethics Repository
 
 1. **Remove AI attribution from all existing commits** (history cleanup)
 2. **Install enforcement hooks** (prevent future violations)
 3. **Update commit templates** (remove AI co-author defaults)
 4. **CI checks** (block merges with AI attribution)
 
-### For Client Projects Using ai-dev-tasks
+### For Client Projects Using ai-ethics
 
 This policy is **installable** via:
 
 ```bash
-bash ai-dev-tasks/scripts/install-attribution-policy.sh
+bash ai-ethics/scripts/install-attribution-policy.sh
 ```
 
 This installs:
@@ -281,28 +276,8 @@ A: They are properly credited in README.md and git history. This policy protects
 
 ### Original Work
 
-This project is a derivative work of:
-
-- **Original Repository**: [snarktank/ai-dev-tasks](https://github.com/snarktank/ai-dev-tasks)
-- **Original Author**: Ryan Carson
-- **License**: MIT License (human authorship required)
-
-### Enhanced By
-
 - **FutureTranz Development Team**
 - **Victor J. Quiñones** - Lead Developer
-- **Repository**: [FutureTranz-Inc/ai-dev-tasks](https://github.com/FutureTranz-Inc/ai-dev-tasks)
-
----
-
-## Contact
-
-For questions about this policy:
-
-- **Repository**: [FutureTranz-Inc/ai-dev-tasks](https://github.com/FutureTranz-Inc/ai-dev-tasks/issues)
-- **Maintainer**: Victor J. Quiñones (FutureTranz)
-
----
 
 **Policy Prepared by:** Victor J. Quiñones (FutureTranz)
 **Last Updated:** October 27, 2025

--- a/docs/GOVERNANCE_NOTICE.md
+++ b/docs/GOVERNANCE_NOTICE.md
@@ -8,7 +8,7 @@
 
 The AI Ethics Policy, GitHub↔Notion Synchronization Policy, and related governance documents in this repository apply to:
 
-- `FutureTranz-Inc/ai-dev-tasks` (upstream)
+- `FutureTranz-Inc/ai-ethics` (upstream)
 - Contributions submitted to upstream via pull request
 
 ---

--- a/scripts/install-attribution-policy.sh
+++ b/scripts/install-attribution-policy.sh
@@ -9,7 +9,7 @@
 #
 # Usage:
 #   cd your-project
-#   bash ai-dev-tasks/scripts/install-attribution-policy.sh
+#   bash ai-ethics/scripts/install-attribution-policy.sh
 #
 
 set -e
@@ -50,11 +50,11 @@ if [ "$CURRENT_DIR" != "$GIT_ROOT" ]; then
     echo ""
 fi
 
-# Check if ai-dev-tasks exists
-if [ ! -d "ai-dev-tasks" ]; then
-    echo -e "${RED}❌ Error: ai-dev-tasks submodule not found${NC}"
-    echo "Please add ai-dev-tasks as a submodule first:"
-    echo "  git submodule add https://github.com/FutureTranz-Inc/ai-dev-tasks.git"
+# Check if ai-ethics exists
+if [ ! -d "ai-ethics" ]; then
+    echo -e "${RED}❌ Error: ai-ethics submodule not found${NC}"
+    echo "Please add ai-ethics as a submodule first:"
+    echo "  git submodule add https://github.com/FutureTranz-Inc/ai-ethics.git"
     exit 1
 fi
 
@@ -74,7 +74,7 @@ if [ -f ".git/hooks/commit-msg" ]; then
     cp .git/hooks/commit-msg .git/hooks/commit-msg.backup
 fi
 
-cp ai-dev-tasks/scripts/hooks/commit-msg .git/hooks/commit-msg
+cp ai-ethics/scripts/hooks/commit-msg .git/hooks/commit-msg
 chmod +x .git/hooks/commit-msg
 echo -e "${GREEN}✅ Installed: commit-msg hook (blocks AI attribution)${NC}"
 INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
@@ -86,7 +86,7 @@ if [ -f ".git/hooks/pre-commit" ]; then
     cp .git/hooks/pre-commit .git/hooks/pre-commit.backup
 fi
 
-cp ai-dev-tasks/scripts/hooks/pre-commit .git/hooks/pre-commit
+cp ai-ethics/scripts/hooks/pre-commit .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 echo -e "${GREEN}✅ Installed: pre-commit hook (strips AI attribution)${NC}"
 INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
@@ -100,7 +100,7 @@ if [ -f "scripts/ci-check-attribution.sh" ]; then
     echo -e "${YELLOW}⚠️  scripts/ci-check-attribution.sh already exists (skipping)${NC}"
     SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
 else
-    cp ai-dev-tasks/scripts/ci-check-attribution.sh scripts/ci-check-attribution.sh
+    cp ai-ethics/scripts/ci-check-attribution.sh scripts/ci-check-attribution.sh
     chmod +x scripts/ci-check-attribution.sh
     echo -e "${GREEN}✅ Installed: CI attribution check script${NC}"
     INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
@@ -115,7 +115,7 @@ if [ -f ".github/workflows/attribution-policy.yml" ]; then
     echo -e "${YELLOW}⚠️  .github/workflows/attribution-policy.yml already exists (skipping)${NC}"
     SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
 else
-    cp ai-dev-tasks/.github/workflows/attribution-policy.yml .github/workflows/attribution-policy.yml
+    cp ai-ethics/.github/workflows/attribution-policy.yml .github/workflows/attribution-policy.yml
     echo -e "${GREEN}✅ Installed: GitHub Actions workflow${NC}"
     INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
 fi
@@ -125,7 +125,7 @@ if [ -f "AI_ATTRIBUTION_POLICY.md" ]; then
     echo -e "${YELLOW}⚠️  AI_ATTRIBUTION_POLICY.md already exists (skipping)${NC}"
     SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
 else
-    cp ai-dev-tasks/AI_ATTRIBUTION_POLICY.md AI_ATTRIBUTION_POLICY.md
+    cp ai-ethics/AI_ATTRIBUTION_POLICY.md AI_ATTRIBUTION_POLICY.md
     echo -e "${GREEN}✅ Installed: AI Attribution Policy document${NC}"
     INSTALLED_COUNT=$((INSTALLED_COUNT + 1))
 fi
@@ -180,7 +180,7 @@ if [ "$VERIFICATION_PASSED" = true ]; then
     echo "🧪 Test the Policy:"
     echo ""
     echo "🧹 Clean Existing History (optional):"
-    echo "   bash ai-dev-tasks/scripts/clean-ai-attribution-history.sh"
+    echo "   bash ai-ethics/scripts/clean-ai-attribution-history.sh"
     echo ""
     echo "✅ Your project now enforces human-only authorship attribution!"
     echo ""


### PR DESCRIPTION
## Summary
- Replace remaining `ai-dev-tasks` references with `ai-ethics` across policy docs, workflow messaging, and installer script
- Align repository and upstream naming so onboarding and attribution guidance point to the current repo
- Keep enforcement behavior unchanged; this is a consistency/documentation cleanup