### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-advocacy.yml
+++ b/.github/workflows/update-advocacy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Update follower counts


### PR DESCRIPTION
Potential fix for [https://github.com/FutureTranz-Inc/ai-ethics/security/code-scanning/7](https://github.com/FutureTranz-Inc/ai-ethics/security/code-scanning/7)

In general, the fix is to add a `permissions` block to the workflow (at the root or job level) that grants only the minimal scopes needed. This documents the workflow’s needs and prevents the `GITHUB_TOKEN` from having broader access than required.

For this specific workflow, the job pushes commits back to the repository, so it requires `contents: write`. There is no evidence of needing other scopes (issues, pull-requests, packages, etc.), so we can keep those implicitly at `none` by not specifying them. The simplest, least-privilege fix is to add a `permissions` block to the `update` job setting `contents: write`.

Concretely, in `.github/workflows/update-advocacy.yml`, under `jobs:`, inside the `update:` job and at the same indentation level as `runs-on:`, add:

```yaml
    permissions:
      contents: write
```

This keeps existing behavior (the workflow can still push changes) while explicitly constraining the token to repository contents write access only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
