### PR TITLE
Add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/ai-ethics-check.yml
+++ b/.github/workflows/ai-ethics-check.yml
@@ -1,5 +1,9 @@
 name: AI Ethics Check
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   ethics-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/attribution-policy.yml
+++ b/.github/workflows/attribution-policy.yml
@@ -8,6 +8,10 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-attribution:
     name: Check AI Attribution Policy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ethics-enforcement.yml
+++ b/.github/workflows/ethics-enforcement.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-ethics-section:
     name: PRD Ethics Section Required

--- a/.github/workflows/update-advocacy.yml
+++ b/.github/workflows/update-advocacy.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 0 * * 0'  # Weekly on Sunday
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit workflow-level `permissions` blocks to all workflows flagged by code scanning
- Apply least-privilege defaults (`contents: read`) for read-only workflows
- Grant only required write scope for workflows that create comments (`issues: write`) or push updates (`contents: write`)

## Security Impact
Resolves open CodeQL `actions/missing-workflow-permissions` alerts by removing implicit token scope and documenting required privileges.